### PR TITLE
ДЗ к занятию 2.4. Retrofit (CRUD)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -56,12 +56,13 @@ dependencies {
     def swiperefreshlayout_version = "1.1.0"
     def lifecycle_version = "2.5.1"
     def mdc_version = "1.8.0"
-    def gson_version = "2.10.1"
     def nav_version = "2.5.3"
     def room_version = "2.5.0"
     def firebase_version = "30.5.0"
-    def okhttp_version = "4.10.0"
     def play_services_base_version = "18.2.0"
+    def retrofit_version = "2.9.0"
+    def retrofitgson_version = "2.9.0"
+    def okhttplogging_version = "4.10.0"
     def glide_version = "4.14.2"
 
     implementation fileTree(dir: "libs", include: ["*.jar"])
@@ -81,15 +82,16 @@ dependencies {
     implementation "androidx.lifecycle:lifecycle-common-java8:$lifecycle_version"
 
     implementation "com.google.android.material:material:$mdc_version"
-    implementation "com.google.code.gson:gson:$gson_version"
     implementation "androidx.navigation:navigation-fragment-ktx:$nav_version"
     implementation "androidx.navigation:navigation-ui-ktx:$nav_version"
     implementation "androidx.room:room-runtime:$room_version"
     kapt "androidx.room:room-compiler:$room_version"
     implementation platform("com.google.firebase:firebase-bom:$firebase_version")
     implementation "com.google.firebase:firebase-messaging-ktx"
-    implementation "com.squareup.okhttp3:okhttp:$okhttp_version"
     implementation "com.google.android.gms:play-services-base:$play_services_base_version"
+    implementation "com.squareup.retrofit2:retrofit:$retrofit_version"
+    implementation "com.squareup.retrofit2:converter-gson:$retrofitgson_version"
+    implementation "com.squareup.okhttp3:logging-interceptor:$okhttplogging_version"
     // kapt "com.github.bumptech.glide:compiler:$glide_version"
     implementation "com.github.bumptech.glide:glide:$glide_version"
 

--- a/app/src/main/java/ru/netology/nmedia/activity/FeedFragment.kt
+++ b/app/src/main/java/ru/netology/nmedia/activity/FeedFragment.kt
@@ -9,6 +9,8 @@ import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
 import androidx.navigation.fragment.findNavController
+import com.google.android.material.snackbar.BaseTransientBottomBar
+import com.google.android.material.snackbar.Snackbar
 import ru.netology.nmedia.R
 import ru.netology.nmedia.adapter.OnInteractionListener
 import ru.netology.nmedia.adapter.PostsAdapter
@@ -58,6 +60,23 @@ class FeedFragment : Fragment() {
             binding.progress.isVisible = state.loading || state.refreshing
             binding.errorGroup.isVisible = state.error
             binding.emptyText.isVisible = state.empty
+
+            if (state.response.code != 0) {
+                Snackbar
+                    .make(
+                        requireView(),
+                        getString(
+                            R.string.error_response,
+                            state.response.message.toString(),
+                            state.response.code
+                        ),
+                        BaseTransientBottomBar.LENGTH_INDEFINITE
+                    )
+                    .setAction(android.R.string.ok) {
+                        return@setAction
+                    }
+                    .show()
+            }
         }
 
         binding.retryButton.setOnClickListener {

--- a/app/src/main/java/ru/netology/nmedia/api/PostsApiService.kt
+++ b/app/src/main/java/ru/netology/nmedia/api/PostsApiService.kt
@@ -1,0 +1,58 @@
+package ru.netology.nmedia.api
+
+import okhttp3.OkHttpClient
+import okhttp3.logging.HttpLoggingInterceptor
+import retrofit2.Call
+import retrofit2.Retrofit
+import retrofit2.converter.gson.GsonConverterFactory
+import retrofit2.create
+import retrofit2.http.*
+import ru.netology.nmedia.BuildConfig
+import ru.netology.nmedia.dto.Post
+import java.util.concurrent.TimeUnit
+
+private const val BASE_URL = "${BuildConfig.NMEDIA_SERVER}/api/slow/"
+
+interface PostsApiService {
+
+    @POST("posts")
+    fun save(@Body post: Post): Call<Post>
+
+    @GET("posts")
+    fun getAll(): Call<List<Post>>
+
+    @GET("posts/{id}")
+    fun getById(@Path("id") id: Long): Call<Post>
+
+    @DELETE("posts/{id}")
+    fun removeById(@Path("id") id: Long): Call<Unit>
+
+    @POST("posts/{id}/likes")
+    fun likeById(@Path("id") id: Long): Call<Post>
+
+    @DELETE("posts/{id}/likes")
+    fun dislikeById(@Path("id") id: Long): Call<Post>
+}
+
+private val logging = HttpLoggingInterceptor().apply {
+    if (BuildConfig.DEBUG) {
+        level = HttpLoggingInterceptor.Level.BODY
+    }
+}
+
+private val client = OkHttpClient.Builder()
+    .addInterceptor(logging)
+    .connectTimeout(30, TimeUnit.SECONDS)
+    .build()
+
+private val retrofit = Retrofit.Builder()
+    .addConverterFactory(GsonConverterFactory.create())
+    .baseUrl(BASE_URL)
+    .client(client)
+    .build()
+
+object ApiPosts {
+    val retrofitService: PostsApiService by lazy {
+        retrofit.create()
+    }
+}

--- a/app/src/main/java/ru/netology/nmedia/model/FeedModel.kt
+++ b/app/src/main/java/ru/netology/nmedia/model/FeedModel.kt
@@ -8,4 +8,10 @@ data class FeedModel(
     val error: Boolean = false,
     val empty: Boolean = false,
     val refreshing: Boolean = false,
+    val response: FeedResponse = FeedResponse()
+)
+
+data class FeedResponse(
+    val code: Int = 0,
+    val message: String? = null
 )

--- a/app/src/main/java/ru/netology/nmedia/repository/PostRepository.kt
+++ b/app/src/main/java/ru/netology/nmedia/repository/PostRepository.kt
@@ -11,6 +11,7 @@ interface PostRepository {
 
     interface ResponseCallback<T> {
         fun onSuccess(result: T) {}
-        fun onError(e: Exception) {}
+        fun onError(code: Int, message: String) {}
+        fun onFailure(e: Exception) {}
     }
 }

--- a/app/src/main/java/ru/netology/nmedia/repository/PostRepository.kt
+++ b/app/src/main/java/ru/netology/nmedia/repository/PostRepository.kt
@@ -4,9 +4,10 @@ import ru.netology.nmedia.dto.Post
 
 interface PostRepository {
     fun getAll(callback: ResponseCallback<List<Post>>)
-    fun likeById(id: Long, callback: ResponseCallback<Post>)
     fun save(post: Post, callback: ResponseCallback<Post>)
-    fun removeById(id: Long, callback: ResponseCallback<Any>)
+    fun removeById(id: Long, callback: ResponseCallback<Unit>)
+    fun likeById(id: Long, callback: ResponseCallback<Post>)
+    fun dislikeById(id: Long, callback: ResponseCallback<Post>)
 
     interface ResponseCallback<T> {
         fun onSuccess(result: T) {}

--- a/app/src/main/java/ru/netology/nmedia/repository/PostRepositoryImpl.kt
+++ b/app/src/main/java/ru/netology/nmedia/repository/PostRepositoryImpl.kt
@@ -1,157 +1,112 @@
 package ru.netology.nmedia.repository
 
-import com.google.gson.Gson
-import com.google.gson.reflect.TypeToken
-import okhttp3.*
-import okhttp3.MediaType.Companion.toMediaType
-import okhttp3.RequestBody.Companion.toRequestBody
-import okhttp3.internal.EMPTY_REQUEST
-import ru.netology.nmedia.BuildConfig
+import retrofit2.Call
+import retrofit2.Callback
+import retrofit2.Response
+import ru.netology.nmedia.api.ApiPosts
 import ru.netology.nmedia.dto.Post
-import java.io.IOException
-import java.util.concurrent.TimeUnit
 
 
 class PostRepositoryImpl : PostRepository {
-    private val client = OkHttpClient.Builder()
-        .connectTimeout(30, TimeUnit.SECONDS)
-        .build()
-    private val gson = Gson()
-    private val typeToken = object : TypeToken<List<Post>>() {}
-    private val typeTokenOnePost = object : TypeToken<Post>() {}
-
-    companion object {
-        private const val BASE_URL = BuildConfig.NMEDIA_SERVER
-        private val jsonType = "application/json".toMediaType()
-    }
 
     private fun getById(id: Long, callback: PostRepository.ResponseCallback<Post>) {
-        val request: Request = Request.Builder()
-            .url("${BASE_URL}/api/slow/posts/$id")
-            .build()
-
-        client.newCall(request)
-            .enqueue(object : Callback {
-                override fun onResponse(call: Call, response: Response) {
-                    val body = response.body?.string() ?: throw RuntimeException("body is null")
-                    try {
-                        callback.onSuccess(gson.fromJson(body, typeTokenOnePost.type))
-                    } catch (e: Exception) {
-                        callback.onError(e)
-                    }
+        ApiPosts.retrofitService.getById(id).enqueue(object : Callback<Post> {
+            override fun onResponse(call: Call<Post>, response: Response<Post>) {
+                if (!response.isSuccessful) {
+                    callback.onError(Exception(response.message()))
+                } else {
+                    callback.onSuccess(requireNotNull(response.body()) { "body is null" })
                 }
+            }
 
-                override fun onFailure(call: Call, e: IOException) {
-                    callback.onError(e)
-                }
-            })
+            override fun onFailure(call: Call<Post>, t: Throwable) {
+                callback.onError(Exception(t))
+            }
+
+        })
     }
 
     override fun getAll(callback: PostRepository.ResponseCallback<List<Post>>) {
-        val request: Request = Request.Builder()
-            .url("${BASE_URL}/api/slow/posts")
-            .build()
-
-        client.newCall(request)
-            .enqueue(object : Callback {
-                override fun onResponse(call: Call, response: Response) {
-                    val body = response.body?.string() ?: throw RuntimeException("body is null")
-                    try {
-                        callback.onSuccess(gson.fromJson(body, typeToken.type))
-                    } catch (e: Exception) {
-                        callback.onError(e)
-                    }
-                }
-
-                override fun onFailure(call: Call, e: IOException) {
-                    callback.onError(e)
-                }
-            })
-    }
-
-    override fun likeById(id: Long, callback: PostRepository.ResponseCallback<Post>) {
-        getById(id, object : PostRepository.ResponseCallback<Post> {
-            override fun onSuccess(result: Post) {
-                val request = if (!result.likedByMe) {
-                    Request.Builder()
-                        .url("${BASE_URL}/api/posts/$id/likes")
-                        .post(EMPTY_REQUEST)
-                        .build()
+        ApiPosts.retrofitService.getAll().enqueue(object : Callback<List<Post>> {
+            override fun onResponse(call: Call<List<Post>>, response: Response<List<Post>>) {
+                if (!response.isSuccessful) {
+                    callback.onError(Exception(response.message()))
                 } else {
-                    Request.Builder()
-                        .url("${BASE_URL}/api/posts/$id/likes")
-                        .delete()
-                        .build()
+                    callback.onSuccess(requireNotNull(response.body()) { "body is null" })
                 }
-
-                client.newCall(request)
-                    .enqueue(object : Callback {
-                        override fun onResponse(call: Call, response: Response) {
-                            val body = response.body?.string() ?: throw RuntimeException("body is null")
-                            try {
-                                callback.onSuccess(gson.fromJson(body, typeTokenOnePost.type))
-                            } catch (e: Exception) {
-                                callback.onError(e)
-                            }
-                        }
-
-                        override fun onFailure(call: Call, e: IOException) {
-                            callback.onError(e)
-                        }
-                    })
             }
 
-            override fun onError(e: Exception) {
-                callback.onError(e)
+            override fun onFailure(call: Call<List<Post>>, t: Throwable) {
+                callback.onError(Exception(t))
             }
         })
     }
 
     override fun save(post: Post, callback: PostRepository.ResponseCallback<Post>) {
-        val request: Request = Request.Builder()
-            .post(gson.toJson(post).toRequestBody(jsonType))
-            .url("${BASE_URL}/api/slow/posts")
-            .build()
-
-        client.newCall(request)
-            .enqueue(object : Callback {
-                override fun onResponse(call: Call, response: Response) {
-                    val body = response.body?.string() ?: throw RuntimeException("body is null")
-                    try {
-                        callback.onSuccess(gson.fromJson(body, typeTokenOnePost.type))
-                    } catch (e: Exception) {
-                        callback.onError(e)
-                    }
+        ApiPosts.retrofitService.save(post).enqueue(object : Callback<Post> {
+            override fun onResponse(call: Call<Post>, response: Response<Post>) {
+                if (!response.isSuccessful) {
+                    callback.onError(Exception(response.message()))
+                } else {
+                    callback.onSuccess(requireNotNull(response.body()) { "body is null" })
                 }
+            }
 
-                override fun onFailure(call: Call, e: IOException) {
-                    callback.onError(e)
-                }
-            })
+            override fun onFailure(call: Call<Post>, t: Throwable) {
+                callback.onError(Exception(t))
+            }
+
+        })
     }
 
-    override fun removeById(id: Long, callback: PostRepository.ResponseCallback<Any>) {
-        val request: Request = Request.Builder()
-            .delete()
-            .url("${BASE_URL}/api/slow/posts/$id")
-            .build()
-
-        client.newCall(request)
-            .enqueue(object : Callback {
-                override fun onResponse(call: Call, response: Response) {
-                    if (response.body == null) {
-                        throw RuntimeException("body is null")
-                    }
-                    try {
-                        callback.onSuccess(Any())
-                    } catch (e: Exception) {
-                        callback.onError(e)
-                    }
+    override fun removeById(id: Long, callback: PostRepository.ResponseCallback<Unit>) {
+        ApiPosts.retrofitService.removeById(id).enqueue(object : Callback<Unit> {
+            override fun onResponse(call: Call<Unit>, response: Response<Unit>) {
+                if (!response.isSuccessful) {
+                    callback.onError(Exception(response.message()))
+                } else {
+                    callback.onSuccess(requireNotNull(response.body()) { "body is null" })
                 }
+            }
 
-                override fun onFailure(call: Call, e: IOException) {
-                    callback.onError(e)
+            override fun onFailure(call: Call<Unit>, t: Throwable) {
+                callback.onError(Exception(t))
+            }
+
+        })
+    }
+
+    override fun likeById(id: Long, callback: PostRepository.ResponseCallback<Post>) {
+        ApiPosts.retrofitService.likeById(id).enqueue(object : Callback<Post> {
+            override fun onResponse(call: Call<Post>, response: Response<Post>) {
+                if (!response.isSuccessful) {
+                    callback.onError(Exception(response.message()))
+                } else {
+                    callback.onSuccess(requireNotNull(response.body()) { "body is null" })
                 }
-            })
+            }
+
+            override fun onFailure(call: Call<Post>, t: Throwable) {
+                callback.onError(Exception(t))
+            }
+
+        })
+    }
+
+    override fun dislikeById(id: Long, callback: PostRepository.ResponseCallback<Post>) {
+        ApiPosts.retrofitService.dislikeById(id).enqueue(object : Callback<Post> {
+            override fun onResponse(call: Call<Post>, response: Response<Post>) {
+                if (!response.isSuccessful) {
+                    callback.onError(Exception(response.message()))
+                } else {
+                    callback.onSuccess(requireNotNull(response.body()) { "body is null" })
+                }
+            }
+
+            override fun onFailure(call: Call<Post>, t: Throwable) {
+                callback.onError(Exception(t))
+            }
+
+        })
     }
 }

--- a/app/src/main/java/ru/netology/nmedia/repository/PostRepositoryImpl.kt
+++ b/app/src/main/java/ru/netology/nmedia/repository/PostRepositoryImpl.kt
@@ -13,16 +13,15 @@ class PostRepositoryImpl : PostRepository {
         ApiPosts.retrofitService.getById(id).enqueue(object : Callback<Post> {
             override fun onResponse(call: Call<Post>, response: Response<Post>) {
                 if (!response.isSuccessful) {
-                    callback.onError(Exception(response.message()))
+                    callback.onError(response.code(), response.message())
                 } else {
                     callback.onSuccess(requireNotNull(response.body()) { "body is null" })
                 }
             }
 
             override fun onFailure(call: Call<Post>, t: Throwable) {
-                callback.onError(Exception(t))
+                callback.onFailure(Exception(t))
             }
-
         })
     }
 
@@ -30,14 +29,14 @@ class PostRepositoryImpl : PostRepository {
         ApiPosts.retrofitService.getAll().enqueue(object : Callback<List<Post>> {
             override fun onResponse(call: Call<List<Post>>, response: Response<List<Post>>) {
                 if (!response.isSuccessful) {
-                    callback.onError(Exception(response.message()))
+                    callback.onError(response.code(), response.message())
                 } else {
                     callback.onSuccess(requireNotNull(response.body()) { "body is null" })
                 }
             }
 
             override fun onFailure(call: Call<List<Post>>, t: Throwable) {
-                callback.onError(Exception(t))
+                callback.onFailure(Exception(t))
             }
         })
     }
@@ -46,16 +45,15 @@ class PostRepositoryImpl : PostRepository {
         ApiPosts.retrofitService.save(post).enqueue(object : Callback<Post> {
             override fun onResponse(call: Call<Post>, response: Response<Post>) {
                 if (!response.isSuccessful) {
-                    callback.onError(Exception(response.message()))
+                    callback.onError(response.code(), response.message())
                 } else {
                     callback.onSuccess(requireNotNull(response.body()) { "body is null" })
                 }
             }
 
             override fun onFailure(call: Call<Post>, t: Throwable) {
-                callback.onError(Exception(t))
+                callback.onFailure(Exception(t))
             }
-
         })
     }
 
@@ -63,16 +61,15 @@ class PostRepositoryImpl : PostRepository {
         ApiPosts.retrofitService.removeById(id).enqueue(object : Callback<Unit> {
             override fun onResponse(call: Call<Unit>, response: Response<Unit>) {
                 if (!response.isSuccessful) {
-                    callback.onError(Exception(response.message()))
+                    callback.onError(response.code(), response.message())
                 } else {
                     callback.onSuccess(requireNotNull(response.body()) { "body is null" })
                 }
             }
 
             override fun onFailure(call: Call<Unit>, t: Throwable) {
-                callback.onError(Exception(t))
+                callback.onFailure(Exception(t))
             }
-
         })
     }
 
@@ -80,16 +77,15 @@ class PostRepositoryImpl : PostRepository {
         ApiPosts.retrofitService.likeById(id).enqueue(object : Callback<Post> {
             override fun onResponse(call: Call<Post>, response: Response<Post>) {
                 if (!response.isSuccessful) {
-                    callback.onError(Exception(response.message()))
+                    callback.onError(response.code(), response.message())
                 } else {
                     callback.onSuccess(requireNotNull(response.body()) { "body is null" })
                 }
             }
 
             override fun onFailure(call: Call<Post>, t: Throwable) {
-                callback.onError(Exception(t))
+                callback.onFailure(Exception(t))
             }
-
         })
     }
 
@@ -97,16 +93,15 @@ class PostRepositoryImpl : PostRepository {
         ApiPosts.retrofitService.dislikeById(id).enqueue(object : Callback<Post> {
             override fun onResponse(call: Call<Post>, response: Response<Post>) {
                 if (!response.isSuccessful) {
-                    callback.onError(Exception(response.message()))
+                    callback.onError(response.code(), response.message())
                 } else {
                     callback.onSuccess(requireNotNull(response.body()) { "body is null" })
                 }
             }
 
             override fun onFailure(call: Call<Post>, t: Throwable) {
-                callback.onError(Exception(t))
+                callback.onFailure(Exception(t))
             }
-
         })
     }
 }

--- a/app/src/main/java/ru/netology/nmedia/viewmodel/PostViewModel.kt
+++ b/app/src/main/java/ru/netology/nmedia/viewmodel/PostViewModel.kt
@@ -4,6 +4,7 @@ import android.app.Application
 import androidx.lifecycle.*
 import ru.netology.nmedia.dto.Post
 import ru.netology.nmedia.model.FeedModel
+import ru.netology.nmedia.model.FeedResponse
 import ru.netology.nmedia.repository.*
 import ru.netology.nmedia.util.SingleLiveEvent
 
@@ -39,7 +40,11 @@ class PostViewModel(application: Application) : AndroidViewModel(application) {
                 _data.postValue(FeedModel(posts = result, empty = result.isEmpty()))
             }
 
-            override fun onError(e: Exception) {
+            override fun onError(code: Int, message: String) {
+                _data.postValue(FeedModel(error = true, response = FeedResponse(code, message)))
+            }
+
+            override fun onFailure(e: Exception) {
                 _data.postValue(FeedModel(error = true))
             }
         })
@@ -61,8 +66,12 @@ class PostViewModel(application: Application) : AndroidViewModel(application) {
                     _postCreated.postValue(Unit)
                 }
 
-                override fun onError(e: Exception) {
-                    TODO("IDK how to show Snackbar here")
+                override fun onError(code: Int, message: String) {
+                    _data.postValue(FeedModel(response = FeedResponse(code, message)))
+                }
+
+                override fun onFailure(e: Exception) {
+                    TODO("IDK what to do here")
                 }
             })
         }
@@ -98,7 +107,11 @@ class PostViewModel(application: Application) : AndroidViewModel(application) {
                 // blinking icon due to query delay is worse.
             }
 
-            override fun onError(e: Exception) {
+            override fun onError(code: Int, message: String) {
+                _data.postValue(FeedModel(posts = old, response = FeedResponse(code, message)))
+            }
+
+            override fun onFailure(e: Exception) {
                 _data.postValue(_data.value?.copy(posts = old))
             }
         }
@@ -121,7 +134,11 @@ class PostViewModel(application: Application) : AndroidViewModel(application) {
                 // Nothing to do because of optimistic model.
             }
 
-            override fun onError(e: Exception) {
+            override fun onError(code: Int, message: String) {
+                _data.postValue(FeedModel(posts = old, response = FeedResponse(code, message)))
+            }
+
+            override fun onFailure(e: Exception) {
                 _data.postValue(_data.value?.copy(posts = old))
             }
         })

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -17,6 +17,7 @@
     <string name="retry_loading">Повторить</string>
     <string name="empty_posts">Постов нет.\nЕсли создадите новый пост, то он появится здесь</string>
     <string name="error_loading">Что-то пошло не так. Попробуйте позднее</string>
+    <string name="error_response">Сервер ответил %1$s (%2$d)</string>
     <string name="save">Сохранить</string>
     <string name="google_play_unavailable">Google Api Недоступно</string>
     <string name="notification_user_liked">%1$s поставил лайк посту %2$s</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -16,6 +16,7 @@
     <string name="retry_loading">Retry</string>
     <string name="empty_posts">There are no posts.\nIf you create a new post, it will appear here</string>
     <string name="error_loading">Something went wrong. Try again later</string>
+    <string name="error_response">Server replied with %1$s (%2$d)</string>
     <string name="save">Save</string>
     <string name="google_play_unavailable">Google Api Unavailable</string>
     <string name="notification_user_liked">User %1$s liked %2$s\'s post</string>


### PR DESCRIPTION
1. Добавлено использование библиотеки Retrofit для SQL запросов;
2. Добавлено уведомление пользователя о вернувшейся с сервера ошибке.

Изначально я планировал сделать:
1. добавить новый метод в интерфейс callback, чтобы различать ошибки onFailure и неуспех в onResponse
2. добавить новые поля в Feed (не помню как точно называется, нет исходников под рукой), чтобы кроме error, туда передать response.message
3. на основе этих данных в адаптере или фрагменте (где получится) вывести snackbar с сообщением. Пока всё просто для get, like, delete
4. для save сложнее. Нужно сохранить черновик (как это делали на прошлом курсе), предложить пользователю повторить операцию, и если он соглашается, вернуться на фрагмент добавления поста с восстановлением данных из черновика.

Не сделано:
* пункт 4 остался не реализован, вместо него сделано такое же уведомление как в пункте 3;
* snackbar не уведомляет о неудавшемся действии. Т.е. из сообщения не возможно понять не удалось удалить или лайк поставить. Кроме того, сервер не выдает response.message, поэтому в сообщении видно только код ошибки. Сюда можно было бы добавить информацию о неудавшемся действии.

Сомнения:
* я не уверен, что метод snackbar.setAction у меня корректный, но он работает и успешно закрывает уведомление.
```kotlin
Snackbar
    .make(...)
    .setAction(android.R.string.ok) {
        return@setAction
    }
    .show()
```
